### PR TITLE
27 5월 1주차 손봉우

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,5 @@
-# meetteam
+# meeteam
 
-A new Flutter project.
-
-
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-=======
 ### 조원
 
 > 손봉우, 박정현, 손예진, 김은수, 심여민

--- a/lib/Appbar/EditAppbar.dart
+++ b/lib/Appbar/EditAppbar.dart
@@ -14,7 +14,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: bgColor,
       // 중앙 로고
       title: const Text(
-        "MEETTEAM",
+        "MEETEAM",
         style: TextStyle(
             color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
       ),

--- a/lib/Appbar/EditAppbar.dart
+++ b/lib/Appbar/EditAppbar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:meetteam/ProfileWritePage.dart';
 
 class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
   const BaseAppbar({required Key key, required this.appBar}) : super(key: key);
@@ -23,19 +22,13 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back, color: iconColor, size: 30),
         tooltip: 'go_back',
-        onPressed: () => {Navigator.pop(context, false)},
+        onPressed: () => {Navigator.pop(context)},
       ),
       actions: <Widget>[
         // 수정 버튼
         IconButton(
           icon: const Icon(Icons.edit, color: iconColor, size: 30),
-          onPressed: () => {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => ProfileWritePage(),
-                ))
-          },
+          onPressed: () => {Navigator.pushNamed(context, '/profileWrite')},
         )
       ],
     );

--- a/lib/Appbar/LogoAppbar.dart
+++ b/lib/Appbar/LogoAppbar.dart
@@ -13,7 +13,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: bgColor,
       // 중앙 로고
       title: const Text(
-        "MEETTEAM",
+        "MEETEAM",
         style: TextStyle(
             color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
       ),

--- a/lib/Appbar/LogoAppbar.dart
+++ b/lib/Appbar/LogoAppbar.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
+  const BaseAppbar({required Key key, required this.appBar}) : super(key: key);
+  final AppBar appBar;
+  static const titleColor = Color(0xff2c4096);
+  static const iconColor = Colors.black;
+  static const bgColor = Color(0xfffafafa);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: bgColor,
+      // 중앙 로고
+      title: const Text(
+        "MEETTEAM",
+        style: TextStyle(
+            color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
+      ),
+      centerTitle: true,
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(appBar.preferredSize.height);
+}

--- a/lib/Appbar/MainAppbar.dart
+++ b/lib/Appbar/MainAppbar.dart
@@ -15,7 +15,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: bgColor,
       // 중앙 로고
       title: const Text(
-        "MEETTEAM",
+        "MEETEAM",
         style: TextStyle(
             color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
       ),

--- a/lib/Appbar/MainAppbar.dart
+++ b/lib/Appbar/MainAppbar.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:meetteam/ProfilePage.dart';
-import 'package:meetteam/ExplorerPage.dart';
 
 class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
   const BaseAppbar({required Key key, required this.appBar}) : super(key: key);
@@ -31,25 +29,13 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
         IconButton(
           icon: const Icon(Icons.search, color: iconColor, size: 30),
           tooltip: 'search',
-          onPressed: () => {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => ExplorerPage(),
-                ))
-          },
+          onPressed: () => {Navigator.pushNamed(context, '/explorer')},
         ),
         // 프로필 버튼
         IconButton(
           icon: const Icon(Icons.account_circle, color: iconColor, size: 30),
           tooltip: 'profile',
-          onPressed: () => {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => ProfilePage(),
-                ))
-          },
+          onPressed: () => {Navigator.pushNamed(context, '/profile')},
         )
       ],
     );

--- a/lib/Appbar/NormalAppbar.dart
+++ b/lib/Appbar/NormalAppbar.dart
@@ -13,7 +13,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: bgColor,
       // 중앙 로고
       title: const Text(
-        "MEETTEAM",
+        "MEETEAM",
         style: TextStyle(
             color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
       ),

--- a/lib/Appbar/NormalAppbar.dart
+++ b/lib/Appbar/NormalAppbar.dart
@@ -22,7 +22,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back, color: iconColor, size: 30),
         tooltip: 'go_back',
-        onPressed: () => {Navigator.pop(context, false)},
+        onPressed: () => {Navigator.pop(context)},
       ),
     );
   }

--- a/lib/Appbar/WriteAppbar.dart
+++ b/lib/Appbar/WriteAppbar.dart
@@ -22,7 +22,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back, color: iconColor, size: 30),
         tooltip: 'go_back',
-        onPressed: () => {Navigator.pop(context, false)},
+        onPressed: () => {Navigator.pop(context)},
       ),
       actions: <Widget>[
         // 저장 버튼

--- a/lib/Appbar/WriteAppbar.dart
+++ b/lib/Appbar/WriteAppbar.dart
@@ -13,7 +13,7 @@ class BaseAppbar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: bgColor,
       // 중앙 로고
       title: const Text(
-        "MEETTEAM",
+        "MEETEAM",
         style: TextStyle(
             color: titleColor, fontSize: 20.0, fontWeight: FontWeight.w700),
       ),

--- a/lib/ApplicationReadPage.dart
+++ b/lib/ApplicationReadPage.dart
@@ -1,7 +1,7 @@
 import "package:flutter/material.dart";
 import "package:meetteam/Appbar/NormalAppbar.dart";
 import "package:meetteam/Color.dart";
-import "package:meetteam/ProfileWritePage.dart";
+
 //스크롤 미구현 상태
 //body 영역에 대한 스크롤 구현
 //프로필 버튼 누르면 프로필로 이동 구현
@@ -21,15 +21,10 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
           height: 60,
           color: CustomColor.color3,
           alignment: Alignment.center,
-          child:
-          const Text(
+          child: const Text(
             "지원",
-            style: TextStyle(
-                fontSize: 30,
-                color: Colors.white
-            ),
-          )
-      ),
+            style: TextStyle(fontSize: 30, color: Colors.white),
+          )),
       body: Container(
         padding: EdgeInsets.all(30),
         child: Column(
@@ -63,12 +58,9 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
             Container(
               padding: EdgeInsets.fromLTRB(0, 20, 0, 10),
               alignment: Alignment.topLeft,
-              child:
-              Text(
+              child: Text(
                 "리더",
-                style: TextStyle(
-                    fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Row(
@@ -80,34 +72,25 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                   width: 50,
                   alignment: Alignment.centerLeft,
                   decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                  ),
+                      color: Colors.grey, shape: BoxShape.circle),
                 ),
                 Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 100,
                     alignment: Alignment.topLeft,
-                    child:
-                    Text("닉네임")
-                ),
+                    child: Text("닉네임")),
                 Container(
                   margin: EdgeInsets.fromLTRB(100, 30, 0, 0),
                   height: 40,
                   width: 80,
                   decoration: const BoxDecoration(
                       color: CustomColor.color3,
-                      borderRadius: BorderRadius.all(Radius.circular(10))
-
-                  ),
+                      borderRadius: BorderRadius.all(Radius.circular(10))),
                   alignment: Alignment.center,
-                  child:
-                  const Text(
+                  child: const Text(
                     "프로필",
-                    style: TextStyle(
-                        color: Colors.white
-                    ),
+                    style: TextStyle(color: Colors.white),
                   ),
                 ),
               ],
@@ -115,20 +98,16 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
             Container(
               margin: EdgeInsets.fromLTRB(0, 20, 0, 0),
               alignment: Alignment.topLeft,
-              child:
-              const Text(
+              child: const Text(
                 "모임",
-                style: TextStyle(
-                    fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Container(
               margin: EdgeInsets.fromLTRB(100, 10, 0, 0),
               height: 30,
               alignment: Alignment.topLeft,
-              child:
-              Row(
+              child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   Row(
@@ -136,9 +115,7 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                       Text("오프라인  "),
                       Text(
                         "zoom",
-                        style:TextStyle(
-                            color: Colors.blueAccent
-                        ),
+                        style: TextStyle(color: Colors.blueAccent),
                       ),
                     ],
                   ),
@@ -148,12 +125,9 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
             ),
             Container(
               alignment: Alignment.topLeft,
-              child:
-              const Text(
+              child: const Text(
                 "모집 인원",
-                style: TextStyle(
-                    fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Row(
@@ -164,18 +138,14 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                   width: 50,
                   alignment: Alignment.centerLeft,
                   decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                  ),
+                      color: Colors.grey, shape: BoxShape.circle),
                 ),
                 Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 80,
                     alignment: Alignment.topLeft,
-                    child:
-                    Text("백엔드")
-                ),
+                    child: Text("백엔드")),
                 Container(
                   margin: EdgeInsets.fromLTRB(0, 30, 0, 0),
                   height: 60,
@@ -185,44 +155,37 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                     children: [
                       Container(
                           child: Column(
-                            children: [
-                              Text("최소 경력"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
-                                height: 20,
-                                width: 50,
-                                alignment: Alignment.center,
-                                decoration: const BoxDecoration(
-                                    color: CustomColor.color1,
-                                    borderRadius: BorderRadius.all(Radius.circular(10))
-                                ),
-                                child:
-                                Text(
-                                  "3년",
-                                  style: TextStyle(
-                                      color: CustomColor.color3
-                                  ),
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("최소 경력"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
+                            height: 20,
+                            width: 50,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
+                                color: CustomColor.color1,
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(10))),
+                            child: Text(
+                              "3년",
+                              style: TextStyle(color: CustomColor.color3),
+                            ),
                           )
-                      ),
+                        ],
+                      )),
                       Container(
                           child: Column(
-                            children: [
-                              Text("필요 기술"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
-                                height: 30,
-                                width: 30,
-                                decoration: const BoxDecoration(
-                                    color: Colors.grey,
-                                    shape: BoxShape.circle
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("필요 기술"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
+                            height: 30,
+                            width: 30,
+                            decoration: const BoxDecoration(
+                                color: Colors.grey, shape: BoxShape.circle),
                           )
-                      ),
+                        ],
+                      )),
                     ],
                   ),
                 ),
@@ -236,18 +199,14 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                   width: 50,
                   alignment: Alignment.centerLeft,
                   decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                  ),
+                      color: Colors.grey, shape: BoxShape.circle),
                 ),
                 Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 80,
                     alignment: Alignment.topLeft,
-                    child:
-                    Text("프론트엔드")
-                ),
+                    child: Text("프론트엔드")),
                 Container(
                   margin: EdgeInsets.fromLTRB(0, 30, 0, 0),
                   height: 60,
@@ -257,44 +216,37 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
                     children: [
                       Container(
                           child: Column(
-                            children: [
-                              Text("최소 경력"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
-                                height: 20,
-                                width: 50,
-                                alignment: Alignment.center,
-                                decoration: const BoxDecoration(
-                                    color: CustomColor.color1,
-                                    borderRadius: BorderRadius.all(Radius.circular(10))
-                                ),
-                                child:
-                                Text(
-                                  "5년",
-                                  style: TextStyle(
-                                      color: CustomColor.color3
-                                  ),
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("최소 경력"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
+                            height: 20,
+                            width: 50,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
+                                color: CustomColor.color1,
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(10))),
+                            child: Text(
+                              "5년",
+                              style: TextStyle(color: CustomColor.color3),
+                            ),
                           )
-                      ),
+                        ],
+                      )),
                       Container(
                           child: Column(
-                            children: [
-                              Text("필요 기술"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
-                                height: 30,
-                                width: 30,
-                                decoration: const BoxDecoration(
-                                    color: Colors.grey,
-                                    shape: BoxShape.circle
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("필요 기술"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
+                            height: 30,
+                            width: 30,
+                            decoration: const BoxDecoration(
+                                color: Colors.grey, shape: BoxShape.circle),
                           )
-                      ),
+                        ],
+                      )),
                     ],
                   ),
                 ),
@@ -303,7 +255,6 @@ class _ApplicationReadPage extends State<ApplicationReadPage> {
           ],
         ),
       ),
-
     );
     // TODO: implement build
     throw UnimplementedError();

--- a/lib/ApplicationWritePage.dart
+++ b/lib/ApplicationWritePage.dart
@@ -1,15 +1,15 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:meetteam/Appbar/WriteAppbar.dart';
 
 class ApplicationWritePage extends StatefulWidget {
   ApplicationWritePage({super.key});
-  
+
   String nickName = _ApplicationWritePageState().nickNameController.text;
   String supportArea = _ApplicationWritePageState().supportAreaController.text;
   String myCareer = _ApplicationWritePageState().myCareerController.text;
   String workingTime = _ApplicationWritePageState().workingTimeController.text;
-  String introduceUser = _ApplicationWritePageState().introduceUserController.text;
+  String introduceUser =
+      _ApplicationWritePageState().introduceUserController.text;
 
   @override
   State<StatefulWidget> createState() => _ApplicationWritePageState();

--- a/lib/MainPage.dart
+++ b/lib/MainPage.dart
@@ -3,7 +3,6 @@ import "package:flutter/material.dart";
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:meetteam/ProjectWritePage.dart';
 import 'package:meetteam/Appbar/MainAppbar.dart';
-import 'package:meetteam/ProjectWritePage.dart';
 import 'package:meetteam/ProjectListPage.dart';
 import 'package:meetteam/Color.dart';
 import 'package:meetteam/Widgets/ProjectCard.dart';
@@ -99,7 +98,7 @@ class MainPage extends StatelessWidget {
                 ),
                 // 추천 프로젝트 리스트
                 CarouselSlider(
-                    items: [
+                    items: const [
                       ProjectCard(
                         title: "프로젝트1",
                         description: "설명1",

--- a/lib/MainPage.dart
+++ b/lib/MainPage.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import "package:flutter/material.dart";
+import 'package:carousel_slider/carousel_slider.dart';
 import 'package:meetteam/ProjectWritePage.dart';
 import 'package:meetteam/Appbar/MainAppbar.dart';
 import 'package:meetteam/ProjectWritePage.dart';
 import 'package:meetteam/ProjectListPage.dart';
 import 'package:meetteam/Color.dart';
+import 'package:meetteam/Widgets/ProjectCard.dart';
 
 class MainPage extends StatelessWidget {
   const MainPage({super.key});
@@ -96,90 +98,52 @@ class MainPage extends StatelessWidget {
                   ],
                 ),
                 // 추천 프로젝트 리스트
-                Stack(children: [
-                  Container(
-                      height: 360,
-                      margin: const EdgeInsets.fromLTRB(0, 10, 50, 10),
-                      padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
-                      decoration: BoxDecoration(
-                          color: CustomColor.color3,
-                          borderRadius: BorderRadius.circular(20)),
-                      child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceAround,
-                                children: <Widget>[
-                                  const ClipOval(
-                                    child: Icon(
-                                      Icons.person,
-                                      size: 50,
-                                    ),
-                                  ),
-                                  const Text(
-                                    "Nickname",
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 18,
-                                        color: Colors.white),
-                                  ),
-                                  Container(
-                                      height: 40,
-                                      width: 100,
-                                      margin: const EdgeInsets.only(top: 5),
-                                      decoration: BoxDecoration(
-                                          color: CupertinoColors.systemGrey3,
-                                          borderRadius:
-                                              BorderRadius.circular(37)),
-                                      child: const Text("D-2",
-                                          style: TextStyle(
-                                              fontWeight: FontWeight.bold,
-                                              fontSize: 30,
-                                              color: Colors.white),
-                                          textAlign: TextAlign.center)),
-                                ]),
-                            Container(
-                              height: 180,
-                              margin: const EdgeInsets.fromLTRB(0, 10, 0, 10),
-                              decoration: const BoxDecoration(
-                                  color: CupertinoColors.systemGrey3),
-                            ),
-                            const Text(
-                              "  프로젝트명",
-                              style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 18,
-                                  color: Colors.white),
-                            ),
-                            const Text(
-                              "   한줄 소개",
-                              style:
-                                  TextStyle(fontSize: 13, color: Colors.white),
-                            )
-                          ])),
-                  Positioned(
-                    bottom: 0,
-                    right: 20,
-                    child: MaterialButton(
-                      onPressed: () {
-                        Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => ProjectWritePage(),
-                            ));
-                      },
-                      color: CupertinoColors.systemGrey3,
-                      textColor: Colors.black,
-                      padding: const EdgeInsets.all(20),
-                      shape: const CircleBorder(),
-                      child: const Icon(
-                        Icons.create,
-                        size: 20,
+                CarouselSlider(
+                    items: [
+                      ProjectCard(
+                        title: "프로젝트1",
+                        description: "설명1",
+                        nickname: "user1",
+                        dDay: "3",
                       ),
+                      ProjectCard(
+                        title: "프로젝트2",
+                        description: "설명2",
+                        nickname: "user2",
+                        dDay: "6",
+                      ),
+                    ],
+                    options: CarouselOptions(
+                      height: 380.0,
+                      enlargeCenterPage: false,
+                      autoPlay: true,
+                      aspectRatio: 16 / 9,
+                      autoPlayCurve: Curves.fastOutSlowIn,
+                      enableInfiniteScroll: true,
+                      autoPlayAnimationDuration: Duration(milliseconds: 800),
+                      viewportFraction: 1,
+                    )),
+                Positioned(
+                  bottom: 0,
+                  right: 20,
+                  child: MaterialButton(
+                    onPressed: () {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ProjectWritePage(),
+                          ));
+                    },
+                    color: CupertinoColors.systemGrey3,
+                    textColor: Colors.black,
+                    padding: const EdgeInsets.all(20),
+                    shape: const CircleBorder(),
+                    child: const Icon(
+                      Icons.create,
+                      size: 20,
                     ),
-                  )
-                ])
+                  ),
+                )
               ]))
         ]));
   }

--- a/lib/MainPage.dart
+++ b/lib/MainPage.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import "package:flutter/material.dart";
 import 'package:carousel_slider/carousel_slider.dart';
-import 'package:meetteam/ProjectWritePage.dart';
 import 'package:meetteam/Appbar/MainAppbar.dart';
-import 'package:meetteam/ProjectListPage.dart';
 import 'package:meetteam/Color.dart';
 import 'package:meetteam/Widgets/ProjectCard.dart';
 
@@ -27,11 +25,7 @@ class MainPage extends StatelessWidget {
                       ),
                       IconButton(
                         onPressed: () {
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => const ProjectListPage(),
-                              ));
+                          Navigator.pushNamed(context, '/projects');
                         },
                         icon: const Icon(Icons.add),
                       ),
@@ -127,11 +121,7 @@ class MainPage extends StatelessWidget {
                   right: 20,
                   child: MaterialButton(
                     onPressed: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => ProjectWritePage(),
-                          ));
+                      Navigator.pushNamed(context, '/projectWrite');
                     },
                     color: CupertinoColors.systemGrey3,
                     textColor: Colors.black,

--- a/lib/ProfilePage.dart
+++ b/lib/ProfilePage.dart
@@ -1,7 +1,6 @@
 import "package:flutter/material.dart";
 import 'package:meetteam/Appbar/EditAppbar.dart';
 import 'ProfileWritePage.dart';
-import 'package:meetteam/ProfileWritePage.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class ProfilePage extends StatelessWidget {

--- a/lib/ProfileWritePage.dart
+++ b/lib/ProfileWritePage.dart
@@ -1,6 +1,5 @@
 import "package:flutter/material.dart";
 import 'package:meetteam/Appbar/NormalAppbar.dart';
-import 'package:meetteam/MainPage.dart';
 
 class ProfileWritePage extends StatefulWidget {
   const ProfileWritePage({super.key});
@@ -217,8 +216,7 @@ class ProfileWrite extends State<ProfileWritePage> {
           ElevatedButton(
             child: Text("저장"),
             onPressed: () {
-              Navigator.push(
-                  context, MaterialPageRoute(builder: (_) => MainPage()));
+              Navigator.pushNamed(context, '/');
             },
           ),
         ]));

--- a/lib/ProjectReadPage.dart
+++ b/lib/ProjectReadPage.dart
@@ -1,7 +1,7 @@
 import "package:flutter/material.dart";
 import "package:meetteam/Appbar/NormalAppbar.dart";
 import "package:meetteam/Color.dart";
-import "package:meetteam/ProjectWritePage.dart";
+
 //스크롤 미구현 상태
 //body 영역에 대한 스크롤 구현
 //프로필 버튼 누르면 프로필로 이동 구현
@@ -18,18 +18,13 @@ class _ProjectReadPage extends State<ProjectReadPage> {
     return Scaffold(
       appBar: BaseAppbar(key: UniqueKey(), appBar: AppBar()),
       bottomNavigationBar: Container(
-        height: 60,
-        color: CustomColor.color3,
-        alignment: Alignment.center,
-        child:
-          const Text(
+          height: 60,
+          color: CustomColor.color3,
+          alignment: Alignment.center,
+          child: const Text(
             "신청자 내역",
-            style: TextStyle(
-              fontSize: 30,
-              color: Colors.white
-            ),
-          )
-      ),
+            style: TextStyle(fontSize: 30, color: Colors.white),
+          )),
       body: Container(
         padding: EdgeInsets.all(30),
         child: Column(
@@ -63,72 +58,56 @@ class _ProjectReadPage extends State<ProjectReadPage> {
             Container(
               padding: EdgeInsets.fromLTRB(0, 20, 0, 10),
               alignment: Alignment.topLeft,
-              child:
-              Text(
+              child: Text(
                 "리더",
-                style: TextStyle(
-                  fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  Container(
-                    margin: EdgeInsets.fromLTRB(0, 10, 0, 0),
-                    height: 50,
-                    width: 50,
-                    alignment: Alignment.centerLeft,
-                    decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                    ),
-                  ),
-                  Container(
+              children: [
+                Container(
+                  margin: EdgeInsets.fromLTRB(0, 10, 0, 0),
+                  height: 50,
+                  width: 50,
+                  alignment: Alignment.centerLeft,
+                  decoration: const BoxDecoration(
+                      color: Colors.grey, shape: BoxShape.circle),
+                ),
+                Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 100,
                     alignment: Alignment.topLeft,
-                    child:
-                      Text("닉네임")
-                  ),
-                  Container(
-                    margin: EdgeInsets.fromLTRB(100, 30, 0, 0),
-                    height: 40,
-                    width: 80,
-                    decoration: const BoxDecoration(
+                    child: Text("닉네임")),
+                Container(
+                  margin: EdgeInsets.fromLTRB(100, 30, 0, 0),
+                  height: 40,
+                  width: 80,
+                  decoration: const BoxDecoration(
                       color: CustomColor.color3,
-                      borderRadius: BorderRadius.all(Radius.circular(10))
-
-                    ),
-                    alignment: Alignment.center,
-                    child:
-                     const Text(
-                      "프로필",
-                       style: TextStyle(
-                         color: Colors.white
-                       ),
-                    ),
+                      borderRadius: BorderRadius.all(Radius.circular(10))),
+                  alignment: Alignment.center,
+                  child: const Text(
+                    "프로필",
+                    style: TextStyle(color: Colors.white),
                   ),
-                ],
-              ),
+                ),
+              ],
+            ),
             Container(
               margin: EdgeInsets.fromLTRB(0, 20, 0, 0),
               alignment: Alignment.topLeft,
-              child:
-              const Text(
+              child: const Text(
                 "모임",
-                style: TextStyle(
-                    fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Container(
-                margin: EdgeInsets.fromLTRB(100, 10, 0, 0),
-                height: 30,
-                alignment: Alignment.topLeft,
-                child:
-              Row(
+              margin: EdgeInsets.fromLTRB(100, 10, 0, 0),
+              height: 30,
+              alignment: Alignment.topLeft,
+              child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   Row(
@@ -136,9 +115,7 @@ class _ProjectReadPage extends State<ProjectReadPage> {
                       Text("오프라인  "),
                       Text(
                         "zoom",
-                        style:TextStyle(
-                            color: Colors.blueAccent
-                        ),
+                        style: TextStyle(color: Colors.blueAccent),
                       ),
                     ],
                   ),
@@ -148,12 +125,9 @@ class _ProjectReadPage extends State<ProjectReadPage> {
             ),
             Container(
               alignment: Alignment.topLeft,
-              child:
-              const Text(
+              child: const Text(
                 "모집 인원",
-                style: TextStyle(
-                    fontSize: 20
-                ),
+                style: TextStyle(fontSize: 20),
               ),
             ),
             Row(
@@ -164,18 +138,14 @@ class _ProjectReadPage extends State<ProjectReadPage> {
                   width: 50,
                   alignment: Alignment.centerLeft,
                   decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                  ),
+                      color: Colors.grey, shape: BoxShape.circle),
                 ),
                 Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 80,
                     alignment: Alignment.topLeft,
-                    child:
-                    Text("백엔드")
-                ),
+                    child: Text("백엔드")),
                 Container(
                   margin: EdgeInsets.fromLTRB(0, 30, 0, 0),
                   height: 60,
@@ -184,45 +154,38 @@ class _ProjectReadPage extends State<ProjectReadPage> {
                     mainAxisAlignment: MainAxisAlignment.spaceAround,
                     children: [
                       Container(
-                        child: Column(
-                          children: [
-                            Text("최소 경력"),
-                            Container(
-                              margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
-                              height: 20,
-                              width: 50,
-                              alignment: Alignment.center,
-                              decoration: const BoxDecoration(
+                          child: Column(
+                        children: [
+                          Text("최소 경력"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
+                            height: 20,
+                            width: 50,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
                                 color: CustomColor.color1,
-                                borderRadius: BorderRadius.all(Radius.circular(10))
-                              ),
-                              child:
-                              Text(
-                                "3년",
-                                style: TextStyle(
-                                  color: CustomColor.color3
-                                ),
-                              ),
-                            )
-                          ],
-                        )
-                      ),
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(10))),
+                            child: Text(
+                              "3년",
+                              style: TextStyle(color: CustomColor.color3),
+                            ),
+                          )
+                        ],
+                      )),
                       Container(
                           child: Column(
-                            children: [
-                              Text("필요 기술"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
-                                height: 30,
-                                width: 30,
-                                decoration: const BoxDecoration(
-                                    color: Colors.grey,
-                                  shape: BoxShape.circle
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("필요 기술"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
+                            height: 30,
+                            width: 30,
+                            decoration: const BoxDecoration(
+                                color: Colors.grey, shape: BoxShape.circle),
                           )
-                      ),
+                        ],
+                      )),
                     ],
                   ),
                 ),
@@ -236,18 +199,14 @@ class _ProjectReadPage extends State<ProjectReadPage> {
                   width: 50,
                   alignment: Alignment.centerLeft,
                   decoration: const BoxDecoration(
-                      color: Colors.grey,
-                      shape: BoxShape.circle
-                  ),
+                      color: Colors.grey, shape: BoxShape.circle),
                 ),
                 Container(
                     margin: EdgeInsets.fromLTRB(20, 0, 0, 0),
                     height: 50,
                     width: 80,
                     alignment: Alignment.topLeft,
-                    child:
-                    Text("프론트엔드")
-                ),
+                    child: Text("프론트엔드")),
                 Container(
                   margin: EdgeInsets.fromLTRB(0, 30, 0, 0),
                   height: 60,
@@ -257,44 +216,37 @@ class _ProjectReadPage extends State<ProjectReadPage> {
                     children: [
                       Container(
                           child: Column(
-                            children: [
-                              Text("최소 경력"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
-                                height: 20,
-                                width: 50,
-                                alignment: Alignment.center,
-                                decoration: const BoxDecoration(
-                                    color: CustomColor.color1,
-                                    borderRadius: BorderRadius.all(Radius.circular(10))
-                                ),
-                                child:
-                                Text(
-                                  "5년",
-                                  style: TextStyle(
-                                      color: CustomColor.color3
-                                  ),
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("최소 경력"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 5, 0, 0),
+                            height: 20,
+                            width: 50,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
+                                color: CustomColor.color1,
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(10))),
+                            child: Text(
+                              "5년",
+                              style: TextStyle(color: CustomColor.color3),
+                            ),
                           )
-                      ),
+                        ],
+                      )),
                       Container(
                           child: Column(
-                            children: [
-                              Text("필요 기술"),
-                              Container(
-                                margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
-                                height: 30,
-                                width: 30,
-                                decoration: const BoxDecoration(
-                                    color: Colors.grey,
-                                  shape: BoxShape.circle
-                                ),
-                              )
-                            ],
+                        children: [
+                          Text("필요 기술"),
+                          Container(
+                            margin: EdgeInsets.fromLTRB(0, 2, 0, 0),
+                            height: 30,
+                            width: 30,
+                            decoration: const BoxDecoration(
+                                color: Colors.grey, shape: BoxShape.circle),
                           )
-                      ),
+                        ],
+                      )),
                     ],
                   ),
                 ),
@@ -303,7 +255,6 @@ class _ProjectReadPage extends State<ProjectReadPage> {
           ],
         ),
       ),
-
     );
     // TODO: implement build
     throw UnimplementedError();

--- a/lib/ProjectWritePage.dart
+++ b/lib/ProjectWritePage.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:meetteam/Appbar/WriteAppbar.dart';
+import 'package:meetteam/Appbar/NormalAppbar.dart';
+import 'package:meetteam/ProjectReadPage.dart';
 
 class ProjectWritePage extends StatefulWidget {
   ProjectWritePage({super.key});
@@ -115,10 +116,14 @@ class _ProjectWritePageState extends State<ProjectWritePage> {
             color: iconColor,
             size: 30,
           ),
-          // const IconButton(
-          //   icon: Icon(Icons.add, color:iconColor, size: 30),
-          //   onPressed: () => {print("hi")},
-          // ),
+        ),
+        ElevatedButton(
+          child: Text("저장"),
+          onPressed: () {
+            Navigator.pop(context);
+            Navigator.push(
+                context, MaterialPageRoute(builder: (_) => ProjectReadPage()));
+          },
         ),
       ]),
     );

--- a/lib/ProjectWritePage.dart
+++ b/lib/ProjectWritePage.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:meetteam/Appbar/NormalAppbar.dart';
-import 'package:meetteam/ProjectReadPage.dart';
 
 class ProjectWritePage extends StatefulWidget {
   ProjectWritePage({super.key});
@@ -121,8 +120,7 @@ class _ProjectWritePageState extends State<ProjectWritePage> {
           child: Text("저장"),
           onPressed: () {
             Navigator.pop(context);
-            Navigator.push(
-                context, MaterialPageRoute(builder: (_) => ProjectReadPage()));
+            Navigator.pushNamed(context, '/project');
           },
         ),
       ]),

--- a/lib/SignupPage.dart
+++ b/lib/SignupPage.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:meetteam/ProfileWritePage.dart';
 import 'package:meetteam/Appbar/NormalAppbar.dart';
 import 'main.dart';
 
@@ -101,8 +100,7 @@ class _SignUpPageState extends State<SignUpPage> {
                         _passwordController1.text ==
                             _passwordController2.text &&
                         _isOK
-                    ? () => Navigator.push(context,
-                        MaterialPageRoute(builder: (_) => ProfileWritePage()))
+                    ? () => Navigator.pushNamed(context, '/')
                     : null,
               ),
             ],

--- a/lib/UserCheckPage.dart
+++ b/lib/UserCheckPage.dart
@@ -1,7 +1,5 @@
 import "package:flutter/material.dart";
 import 'package:meetteam/Appbar/NormalAppbar.dart';
-import 'package:meetteam/UserCheckPage.dart';
-import 'package:meetteam/UserListPage.dart';
 
 class UserCheckPage extends StatelessWidget {
   static const color1 = Color(0Xff4676BA);
@@ -97,10 +95,7 @@ class UserCheckPage extends StatelessWidget {
                   child: ElevatedButton(
                       child: Text("확정", style: TextStyle(fontSize: 40)),
                       onPressed: () {
-                        Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => UserList()));
+                        Navigator.pushNamed(context, '/userList');
                       }))
             ]));
   }

--- a/lib/UserListPage.dart
+++ b/lib/UserListPage.dart
@@ -1,6 +1,5 @@
 import "package:flutter/material.dart";
 import 'package:meetteam/Appbar/NormalAppbar.dart';
-import 'package:meetteam/UserCheckPage.dart';
 
 class UserList extends StatelessWidget {
   static const color1 = Color(0Xff4676BA);
@@ -27,12 +26,13 @@ class UserList extends StatelessWidget {
               //각 신청자별 상자-1
               GestureDetector(
                   onTap: () {
-                    Navigator.pushNamedAndRemoveUntil(
-                        context, '/', (_) => false);
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => UserCheckPage()));
+                    Navigator.pushNamed(context, '/UserCheckPage');
+                    // Navigator.pushNamedAndRemoveUntil(
+                    //     context, '/', (_) => false);
+                    // Navigator.push(
+                    //     context,
+                    //     MaterialPageRoute(
+                    //         builder: (context) => UserCheckPage()));
                   },
                   child: Container(
                     margin: const EdgeInsets.only(top: 20),

--- a/lib/Widgets/ProjectCard.dart
+++ b/lib/Widgets/ProjectCard.dart
@@ -3,15 +3,16 @@ import 'package:meetteam/Color.dart';
 import 'package:flutter/cupertino.dart';
 
 class ProjectCard extends StatelessWidget {
-  String title;
-  String description;
-  String dDay;
-  String nickname;
-  ProjectCard(
-      {required this.title,
+  final String title;
+  final String description;
+  final String nickname;
+  final String dDay;
+  const ProjectCard(
+      {super.key,
+      required this.title,
       required this.description,
-      required this.dDay,
-      required this.nickname});
+      required this.nickname,
+      required this.dDay});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/Widgets/ProjectCard.dart
+++ b/lib/Widgets/ProjectCard.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:meetteam/Color.dart';
+import 'package:flutter/cupertino.dart';
+
+class ProjectCard extends StatelessWidget {
+  String title;
+  String description;
+  String dDay;
+  String nickname;
+  ProjectCard(
+      {required this.title,
+      required this.description,
+      required this.dDay,
+      required this.nickname});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        height: 360,
+        margin: const EdgeInsets.fromLTRB(0, 10, 50, 10),
+        padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+        decoration: BoxDecoration(
+            color: CustomColor.color3, borderRadius: BorderRadius.circular(20)),
+        child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: <Widget>[
+                    const ClipOval(
+                      child: Icon(
+                        Icons.person,
+                        size: 50,
+                      ),
+                    ),
+                    Text(
+                      nickname,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 18,
+                          color: Colors.white),
+                    ),
+                    Container(
+                        height: 40,
+                        width: 100,
+                        margin: const EdgeInsets.only(top: 5),
+                        decoration: BoxDecoration(
+                            color: CupertinoColors.systemGrey3,
+                            borderRadius: BorderRadius.circular(37)),
+                        child: Text("D-$dDay",
+                            style: const TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 30,
+                                color: Colors.white),
+                            textAlign: TextAlign.center)),
+                  ]),
+              Container(
+                height: 180,
+                margin: const EdgeInsets.fromLTRB(0, 10, 0, 10),
+                decoration:
+                    const BoxDecoration(color: CupertinoColors.systemGrey3),
+              ),
+              Container(
+                  margin: const EdgeInsets.fromLTRB(20, 0, 0, 0),
+                  child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18,
+                              color: Colors.white),
+                        ),
+                        Text(
+                          description,
+                          style: TextStyle(fontSize: 13, color: Colors.white),
+                        )
+                      ])),
+            ]));
+  }
+}

--- a/lib/Widgets/ProjectCard.dart
+++ b/lib/Widgets/ProjectCard.dart
@@ -3,9 +3,13 @@ import 'package:meetteam/Color.dart';
 import 'package:flutter/cupertino.dart';
 
 class ProjectCard extends StatelessWidget {
+  // 프로젝트 제목
   final String title;
+  // 프로젝트 설명
   final String description;
+  // user 이름
   final String nickname;
+  // D-day
   final String dDay;
   const ProjectCard(
       {super.key,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:meetteam/SignupPage.dart';
+import 'package:meetteam/MainPage.dart';
+import 'package:meetteam/ProfilePage.dart';
+import 'package:meetteam/ExplorerPage.dart';
+import 'package:meetteam/ProjectListPage.dart';
+import 'package:meetteam/ProjectWritePage.dart';
+import 'package:meetteam/ProfileWritePage.dart';
+import 'package:meetteam/ProjectReadPage.dart';
+import 'package:meetteam/UserListPage.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,9 +19,19 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(),
-      home: SignUpPage(),
-    );
+        title: 'Flutter Demo',
+        theme: ThemeData(),
+        initialRoute: '/signup',
+        routes: {
+          '/signup': (context) => SignUpPage(),
+          '/': (context) => MainPage(),
+          '/projects': (context) => ProjectListPage(),
+          '/projectWrite': (context) => ProjectWritePage(),
+          '/project': (context) => ProjectReadPage(),
+          '/profile': (context) => ProfilePage(),
+          '/profileWrite': (context) => ProfileWritePage(),
+          '/explorer': (context) => ExplorerPage(),
+          '/userList': (context) => UserList(),
+        });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   url_launcher: ^6.1.10
+  carousel_slider: ^4.0.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
1. 로고만 있는 Appbar 구현
    * 캡쳐
  ![image](https://user-images.githubusercontent.com/68285620/236987710-cbca89a9-a020-48b0-b763-ab3a24924a0c.png)
    * Appbar/LogoAppbar.dart
    * 적용은 하지 않은 상태
2. 프로젝트 글쓰기 저장 버튼 -> 프로젝트 보기 페이지
    * 캡쳐
  ![image](https://user-images.githubusercontent.com/68285620/236988007-ad370b30-bf06-4ca3-aa23-32c240dee765.png)
    * Appbar에 있는 저장 버튼 제거 (WriteAppbar -> NormalAppbar)
    * 저장 버튼 아래에 구현 (프로필 저장 페이지와 통일)
    * 프로젝트 보기 페이지로 이동
3. 추천 넘어가게 하는거
    * 캡쳐  
  ![image](https://user-images.githubusercontent.com/68285620/236995819-f48099e7-5882-41fa-8ad7-42862e1ed293.png)
    * ProjectCard 파일로 분리
4. Appbar 라벨 수정
    * MEATTEAM -> MEEATEAM
6. 라우팅 페이지
    * 코드
![image](https://github.com/computerteam9/MEETEAM/assets/68285620/0d8b6651-fbcc-464c-be94-f9967bb431eb)
    * 기존에 직접 import하는 방식에서 NamedRouter방식으로 변경
